### PR TITLE
adding options and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ git add README.md temp.txt
 ```
 
 The above command states that changes to `README.md` are part of this commit, and that `temp.txt` is similarly part of this commit.
+If you know that you would like everything in the current directory to be added to the commit then you can use . instead of the file names.
 
 You can use `git status` again to see the effect of this staging.
 For this particular example, we see the following:
@@ -222,6 +223,7 @@ git commit
 
 This will bring up an editor (honoring the `$EDITOR` environment variable), allowing you to write a descriptive message (the _commit message_) for your commit.
 Once you save your message, your commit will be done.
+If you use the -m option you can include the message inline. 
 You can verify that your commit did something like so:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Let's make a new branch, using the following command:
 git checkout -b updated
 ```
 
-This creates a new branch named `updated`, which splits off from the `master` branch.
+This creates a new branch named `updated`, which splits off from the `master` branch. If you want to switch to another already created branch you can omit the -b.
 If you run `git branch` again, you should see the following:
 
 ```

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,1 @@
+It was not explicitly mentioned to make this file but i will make it out of fear. 


### PR DESCRIPTION
added why to omit -b when using git checkout 
using '.' instead of writing out all the files 
using -m instead of using the editor to write things inline